### PR TITLE
Fix multi-thread related mod building problem

### DIFF
--- a/fetch/workflow_template.yaml
+++ b/fetch/workflow_template.yaml
@@ -56,10 +56,10 @@ jobs:
           cd build/repo
           chmod +x ./gradlew
           if [ "$$GRADLE_WRAPPER_CHECK" = 'true' ]; then
-            ./gradlew -I ../setup.gradle build
+            ./gradlew -I ../setup.gradle build --max-workers=1
           else
             echo '::warning::Gradle wrapper does not seem to exist, this setup is not recommended. Using system-level gradle instead.'
-            gradle -I ../setup.gradle build
+            gradle -I ../setup.gradle build --max-workers=1
           fi
       - name: Dedicated Server Launching Test
         id: dedicated_server_launching


### PR DESCRIPTION
Disable multi-thread in build step to prevent disordered task executions, like task A depends on task B but runs before task B.