### PR TITLE
Add Setup Gradle Step to Enable Gradle Cache for Faster Builds

### DIFF
--- a/fetch/workflow_template.yaml
+++ b/fetch/workflow_template.yaml
@@ -55,6 +55,10 @@ jobs:
           git submodule init
           git submodule update
           [ -f build.gradle ] || [ -f build.gradle.kts ] || { echo '::error::Git 仓库检出疑似失败，请检查碧螺春中分支名是否正确！'; exit -1; }
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: false
       - name: Validate Gradle Wrapper
         id: gradle_wrapper_check
         continue-on-error: true


### PR DESCRIPTION
This change introduces a Gradle setup step that enables Gradle's caching mechanism, which helps avoid redundant downloads of Gradle and dependencies.

For more details on how Gradle caching works, see [Gradle's official documentation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#how-gradle-user-home-caching-works).